### PR TITLE
Change wandb log directory to fix wandb bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Custom
-.wandb_log
+wandb_log/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/train_atari.py
+++ b/train_atari.py
@@ -25,7 +25,7 @@ def main() -> None:
     ARGS = get_train_args()
 
     # Setup wandb
-    wandb.init(project="rlee", dir=".wandb_log", config=ARGS)
+    wandb.init(project="rlee", dir="wandb_log", config=ARGS)
 
     # Setup Environment
     env = make_env(ARGS.ENV_ID)

--- a/train_classic.py
+++ b/train_classic.py
@@ -25,7 +25,7 @@ def main() -> None:
     ARGS = get_train_args()
 
     # Setup wandb
-    wandb.init(project="rlee", dir=".wandb_log", config=ARGS)
+    wandb.init(project="rlee", dir="wandb_log", config=ARGS)
 
     # Setup Environment
     env = make_env(ARGS.ENV_ID)


### PR DESCRIPTION
It seems like wandb does not allow hidden directories (as in, directories beginning with dot ".")